### PR TITLE
clarify types for rust/pull/44287

### DIFF
--- a/cov/src/graph.rs
+++ b/cov/src/graph.rs
@@ -232,7 +232,7 @@ impl Graph {
                     None
                 }
             })
-            .sum();
+            .sum::<u64>();
 
         let report_function = report::Function {
             name: source.name,


### PR DESCRIPTION
As you know, if rust/pull/44287 lands then [cargobomb](https://github.com/rust-lang/rust/pull/44287#issuecomment-329089956) tells us that this line will have a type ambiguity error, so this is a PR to preemptively prevent that.

Thank you!